### PR TITLE
feat: Implement Redis primary/replica support and health checks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ci-cd-pipeline-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -328,6 +331,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-test, rust-integration-tests, compose-failover-test, integration-test, security]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -456,6 +462,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: [lint, unit-test, rust-integration-tests, compose-failover-test, integration-test, security]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -163,10 +163,37 @@ jobs:
             kill "$LDAP_AUTH_PID" || true
           fi
 
+  compose-failover-test:
+    name: Compose Failover Test
+    runs-on: ubuntu-latest
+    needs: [rust-integration-tests]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Install LDAP tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ldap-utils
+
+      - name: Run compose-based Redis failover test
+        run: |
+          chmod +x tests/ldap_replica_failover_test.sh
+          bash tests/ldap_replica_failover_test.sh
+        env:
+          DOCKER_BUILDKIT: 1
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, rust-integration-tests]
+    needs: [lint, rust-integration-tests, compose-failover-test]
 
     steps:
       - name: Checkout code
@@ -191,7 +218,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: release-binaries
           path: |
@@ -220,7 +247,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-binaries
           path: target/release/
@@ -299,7 +326,7 @@ jobs:
   build-amd64:
     name: Build Docker Image (amd64)
     runs-on: ubuntu-latest
-    needs: [lint, unit-test, rust-integration-tests, integration-test, security]
+    needs: [lint, unit-test, rust-integration-tests, compose-failover-test, integration-test, security]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -311,7 +338,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -330,7 +357,7 @@ jobs:
             type=raw,value=latest-amd64,enable={{is_default_branch}}
 
       - name: Build and push amd64 image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -427,7 +454,7 @@ jobs:
   build-arm64:
     name: Build Docker Image (arm64)
     runs-on: ubuntu-24.04-arm
-    needs: [lint, unit-test, rust-integration-tests, integration-test, security]
+    needs: [lint, unit-test, rust-integration-tests, compose-failover-test, integration-test, security]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -439,7 +466,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -458,7 +485,7 @@ jobs:
             type=raw,value=latest-arm64,enable={{is_default_branch}}
 
       - name: Build and push arm64 image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -580,7 +607,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -602,7 +629,7 @@ jobs:
 
       - name: Build image for verification (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: false

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ A production-ready, lightweight Rust-based LDAP authentication service with REST
 - 📂 **LDAP Interface** supporting bind, search, whoami, unbind operations
 - ✅ **LDAP Compliance Tests** with ldapsearch validation (RFC 4511/4532)
 - 🔒 **LDAP Search Authorization** - restrict search operations to specific organizations
-- 💾 **Redis Backend** with connection pooling and caching
+- 💾 **Redis Backend** with primary/write connection pooling and optional read replica fallback
 - 🔒 **TLS Support** for both API and LDAP servers
 - 📊 **Prometheus Metrics** for production monitoring
 - 📝 **Audit Logging** for compliance and security
 - ✅ **Full Test Coverage** - 56 tests including integration tests
-- 🏥 **Health Checks** with dependency status
+- 🏥 **Health Checks** with healthy/degraded/unhealthy dependency status
 - ⚡ **High Performance** with bearer token caching
 
 ## Quick Start
@@ -57,6 +57,10 @@ docker run -d -p 6379:6379 redis:7-alpine
 export API_BEARER_TOKEN="your-secure-token"
 export REDIS_HOST="127.0.0.1"
 export REDIS_PORT="6379"
+
+# Optional: serve LDAP auth and reads from a replica if the primary is offline
+# export REDIS_REPLICA_HOST="127.0.0.1"
+# export REDIS_REPLICA_PORT="6380"
 
 # 3. Run the service
 cargo run --release
@@ -107,7 +111,7 @@ curl -H "Authorization: Bearer your-token" http://localhost:8080/api/users/myorg
 - `DELETE /api/groups/:org/:name/members/:username` - Remove user from group
 
 ### Health & Monitoring
-- `GET /health` - Health check with Redis status
+- `GET /health` - Health check with healthy/degraded/unhealthy Redis status
 - `GET /metrics` - Prometheus metrics
 
 ## LDAP Operations
@@ -171,6 +175,12 @@ API_PORT=8080
 LDAP_HOST=0.0.0.0
 LDAP_PORT=3893
 RUST_LOG=info
+
+# Redis read replica (optional)
+REDIS_REPLICA_HOST=redis-replica
+REDIS_REPLICA_PORT=6379
+REDIS_REPLICA_USERNAME=replica-user
+REDIS_REPLICA_PASSWORD=replica-password
 
 # TLS (optional)
 TLS_CERT_PATH=/path/to/cert.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   redis:
     image: redis:7-alpine
@@ -14,6 +12,20 @@ services:
       timeout: 3s
       retries: 5
 
+  redis-replica:
+    image: redis:7-alpine
+    ports:
+      - "6391:6391"
+    command: ["redis-server", "--port", "6391", "--replicaof", "redis", "6390"]
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6391", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   ldap-auth:
     build:
       context: .
@@ -24,6 +36,8 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6390
+      - REDIS_REPLICA_HOST=redis-replica
+      - REDIS_REPLICA_PORT=6391
       - API_PORT=8080
       - LDAP_PORT=3389
       - LDAP_BASE_DN=dc=example,dc=com
@@ -31,6 +45,8 @@ services:
       - API_BEARER_TOKEN=asdf
     depends_on:
       redis:
+        condition: service_healthy
+      redis-replica:
         condition: service_healthy
     restart: unless-stopped
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,6 +16,10 @@
 | `REDIS_PORT` | `6379` | Redis server port |
 | `REDIS_USERNAME` | - | Redis username (optional, for ACL) |
 | `REDIS_PASSWORD` | - | Redis password (optional) |
+| `REDIS_REPLICA_HOST` | - | Optional read-only replica hostname used for auth and other read operations when the primary is unavailable |
+| `REDIS_REPLICA_PORT` | primary port | Optional replica port |
+| `REDIS_REPLICA_USERNAME` | primary username | Optional replica username override |
+| `REDIS_REPLICA_PASSWORD` | primary password | Optional replica password override |
 
 ### Optional Configuration
 
@@ -38,6 +42,8 @@
 export API_BEARER_TOKEN="my-secure-token"
 export REDIS_HOST="127.0.0.1"
 export REDIS_PORT="6379"
+export REDIS_REPLICA_HOST="127.0.0.1"
+export REDIS_REPLICA_PORT="6380"
 export API_PORT="8080"
 export RUST_LOG="debug"
 ```
@@ -50,6 +56,8 @@ Create a `.env` file in the project root:
 API_BEARER_TOKEN=my-secure-token
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
+REDIS_REPLICA_HOST=127.0.0.1
+REDIS_REPLICA_PORT=6380
 API_PORT=8080
 LDAP_PORT=3389
 RUST_LOG=info
@@ -62,6 +70,8 @@ docker run -d \
   -e API_BEARER_TOKEN=my-token \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
+  -e REDIS_REPLICA_HOST=redis-replica \
+  -e REDIS_REPLICA_PORT=6379 \
   -e RUST_LOG=info \
   -p 8080:8080 \
   ldap-auth-rs:latest
@@ -77,6 +87,8 @@ services:
       API_BEARER_TOKEN: my-secure-token
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_REPLICA_HOST: redis-replica
+      REDIS_REPLICA_PORT: 6379
       API_PORT: 8080
       RUST_LOG: info
 ```
@@ -99,6 +111,8 @@ metadata:
 data:
   REDIS_HOST: redis
   REDIS_PORT: "6379"
+  REDIS_REPLICA_HOST: redis-replica
+  REDIS_REPLICA_PORT: "6379"
   API_PORT: "8080"
   RUST_LOG: info
 ```
@@ -112,6 +126,12 @@ The application validates configuration on startup and will **fail fast** if:
 - Port numbers are out of range
 
 This ensures deployment issues are caught immediately.
+
+If a replica is configured, startup succeeds when either:
+- The primary is reachable, or
+- The primary is down but the replica is reachable
+
+In the second case the service starts in a read-only degraded mode. LDAP bind/authentication and other reads continue to work against the replica, while write operations keep requiring the primary.
 
 ## Security Best Practices
 
@@ -154,6 +174,21 @@ REDIS_PORT=6379
 REDIS_USERNAME=myuser
 REDIS_PASSWORD=my-secure-password
 # Results in: redis://myuser:my-secure-password@redis.example.com:6379
+
+# With a read replica inheriting the primary credentials
+REDIS_HOST=redis-primary.example.com
+REDIS_PORT=6379
+REDIS_USERNAME=myuser
+REDIS_PASSWORD=my-secure-password
+REDIS_REPLICA_HOST=redis-replica.example.com
+# Results in: redis://myuser:my-secure-password@redis-replica.example.com:6379
+
+# With replica-specific credentials
+REDIS_REPLICA_HOST=redis-replica.example.com
+REDIS_REPLICA_PORT=6380
+REDIS_REPLICA_USERNAME=replica-user
+REDIS_REPLICA_PASSWORD=replica-password
+# Results in: redis://replica-user:replica-password@redis-replica.example.com:6380
 ```
 
 **Security best practices:**

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: ldap-auth
 
 resources:
 - ../../base
+- redis-replica-deployment.yaml
+- redis-replica-service.yaml
 # Ingress disabled by default (internal service)
 # Uncomment if external access is required:
 # - ingress.yaml
@@ -22,6 +24,8 @@ configMapGenerator:
   - RUST_LOG=ldap_auth_rs=info
   - CACHE_TTL=600
   - CACHE_MAX_SIZE=50000
+  - REDIS_REPLICA_HOST=redis-replica-service
+  - REDIS_REPLICA_PORT=6379
 
 images:
 - name: docker.io/falkordb/ldap-auth-rs

--- a/k8s/overlays/production/redis-replica-deployment.yaml
+++ b/k8s/overlays/production/redis-replica-deployment.yaml
@@ -39,6 +39,8 @@ spec:
             - redis-server
             - --requirepass
             - $(REDIS_PASSWORD)
+            - --masterauth
+            - $(REDIS_PASSWORD)
             - --maxmemory
             - 819mb
             - --maxmemory-policy

--- a/k8s/overlays/production/redis-replica-deployment.yaml
+++ b/k8s/overlays/production/redis-replica-deployment.yaml
@@ -30,6 +30,10 @@ spec:
         seccompProfile:
           type: RuntimeDefault
 
+      volumes:
+        - name: redis-config
+          emptyDir: {}
+
       containers:
         - name: redis
           image: redis:7-alpine

--- a/k8s/overlays/production/redis-replica-deployment.yaml
+++ b/k8s/overlays/production/redis-replica-deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-replica
+  labels:
+    app.kubernetes.io/part-of: ldap-auth
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/name: redis-replica
+spec:
+  serviceName: redis-replica-headless
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cache
+      app.kubernetes.io/name: redis-replica
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: ldap-auth
+        app.kubernetes.io/component: cache
+        app.kubernetes.io/name: redis-replica
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+
+          command:
+            - redis-server
+            - --requirepass
+            - $(REDIS_PASSWORD)
+            - --maxmemory
+            - 819mb
+            - --maxmemory-policy
+            - allkeys-lru
+            - --save
+            - "900 1"
+            - --save
+            - "300 10"
+            - --save
+            - "60 10000"
+            - --appendonly
+            - "yes"
+            - --appendfsync
+            - everysec
+            - --replicaof
+            - redis-service
+            - "6379"
+
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ldap-auth-secrets
+                  key: REDIS_PASSWORD
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: ldap-auth-secrets
+                  key: REDIS_PASSWORD
+
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli ping | grep PONG
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli ping | grep PONG
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 999
+            capabilities:
+              drop:
+                - ALL
+
+          volumeMounts:
+            - name: redis-replica-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /tmp
+
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-replica-data
+      labels:
+        app.kubernetes.io/part-of: ldap-auth
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi

--- a/k8s/overlays/production/redis-replica-service.yaml
+++ b/k8s/overlays/production/redis-replica-service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-replica-service
+  labels:
+    app.kubernetes.io/part-of: ldap-auth
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/name: redis-replica
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/name: redis-replica
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: redis
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-replica-headless
+  labels:
+    app.kubernetes.io/part-of: ldap-auth
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/name: redis-replica
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/name: redis-replica
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: redis
+    protocol: TCP

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,23 +2,30 @@
 
 # Test script for ldap-auth-rs
 
-set -e
+set -euo pipefail
 
 echo "🧪 Running LDAP Auth RS tests..."
 
-# Start Redis for testing if not running
-if ! docker ps | grep -q ldap-auth-redis-test; then
-    echo "🐳 Starting test Redis container..."
-    docker run -d \
-        --name ldap-auth-redis-test \
-        -p 6380:6379 \
-        redis:7-alpine
-    
-    # Wait for Redis to be ready
-    sleep 2
-fi
+cleanup() {
+    echo "🧹 Cleaning up compose stack..."
+    docker compose down -v || true
+}
 
-export TEST_REDIS_URL="redis://127.0.0.1:6380"
+trap cleanup EXIT
+
+echo "🐳 Starting Redis primary/replica test stack..."
+docker compose up -d redis redis-replica
+
+echo "⏳ Waiting for Redis services to be ready..."
+for _ in $(seq 1 30); do
+    if docker compose exec -T redis redis-cli -p 6390 ping | grep -q PONG && \
+       docker compose exec -T redis-replica redis-cli -p 6391 ping | grep -q PONG; then
+        break
+    fi
+    sleep 1
+done
+
+export TEST_REDIS_URL="redis://127.0.0.1:6390/15"
 
 # Run unit tests
 echo "📋 Running unit tests..."
@@ -26,7 +33,10 @@ cargo test --lib
 
 # Run integration tests
 echo "🔗 Running integration tests..."
-cargo test --test integration_test
+cargo test --tests -- --test-threads=1
+
+echo "🔁 Running compose-backed replica failover test..."
+bash tests/ldap_replica_failover_test.sh
 
 # Run all tests with coverage (if tarpaulin is installed)
 if command -v cargo-tarpaulin &> /dev/null; then
@@ -34,11 +44,6 @@ if command -v cargo-tarpaulin &> /dev/null; then
     cargo tarpaulin --out Html --output-dir coverage
     echo "✅ Coverage report generated in coverage/index.html"
 fi
-
-# Cleanup
-echo "🧹 Cleaning up test container..."
-docker stop ldap-auth-redis-test || true
-docker rm ldap-auth-redis-test || true
 
 echo ""
 echo "✅ All tests passed!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,14 +17,20 @@ echo "🐳 Starting Redis primary/replica test stack..."
 docker compose up -d redis redis-replica
 
 echo "⏳ Waiting for Redis services to be ready..."
+redis_ready=false
 for _ in $(seq 1 30); do
     if docker compose exec -T redis redis-cli -p 6390 ping | grep -q PONG && \
        docker compose exec -T redis-replica redis-cli -p 6391 ping | grep -q PONG; then
+        redis_ready=true
         break
     fi
     sleep 1
 done
 
+if [ "$redis_ready" != true ]; then
+    echo "❌ Redis primary/replica did not become ready after 30 seconds. Aborting tests."
+    exit 1
+fi
 export TEST_REDIS_URL="redis://127.0.0.1:6390/15"
 
 # Run unit tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -41,6 +41,9 @@ cargo test --lib
 echo "🔗 Running integration tests..."
 cargo test --tests -- --test-threads=1
 
+echo "🛑 Stopping shared Redis services before isolated failover compose test..."
+docker compose stop redis redis-replica
+
 echo "🔁 Running compose-backed replica failover test..."
 bash tests/ldap_replica_failover_test.sh
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,6 +52,9 @@ struct ApiResponse<T> {
 struct HealthStatus {
     status: String, // "healthy", "degraded", "unhealthy"
     redis: bool,
+    redis_primary: bool,
+    redis_replica: bool,
+    read_only: bool,
     timestamp: String,
 }
 
@@ -226,10 +229,21 @@ async fn get_user_groups(
 
 // Health check
 async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, AppError> {
-    let redis_healthy = db.health_check().await.unwrap_or(false);
+    let connection_status = db
+        .connection_status()
+        .await
+        .unwrap_or(crate::db::DbConnectionHealth {
+            can_read: false,
+            can_write: false,
+            primary_available: false,
+            replica_available: false,
+        });
+    let redis_healthy = connection_status.can_read;
 
-    let status = if redis_healthy {
+    let status = if connection_status.can_write {
         "healthy"
+    } else if connection_status.can_read {
+        "degraded"
     } else {
         "unhealthy"
     };
@@ -237,10 +251,13 @@ async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, A
     let health = HealthStatus {
         status: status.to_string(),
         redis: redis_healthy,
+        redis_primary: connection_status.primary_available,
+        redis_replica: connection_status.replica_available,
+        read_only: connection_status.can_read && !connection_status.can_write,
         timestamp: Utc::now().to_rfc3339(),
     };
 
-    let http_status = if redis_healthy {
+    let http_status = if connection_status.can_write || connection_status.can_read {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/src/api.rs
+++ b/src/api.rs
@@ -238,7 +238,7 @@ async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, A
             primary_available: false,
             replica_available: false,
         });
-    let redis_healthy = connection_status.can_write;
+    let redis_healthy = connection_status.can_read || connection_status.can_write;
 
     let status = if connection_status.can_write {
         "healthy"
@@ -257,7 +257,7 @@ async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, A
         timestamp: Utc::now().to_rfc3339(),
     };
 
-    let http_status = if connection_status.can_write {
+    let http_status = if connection_status.can_read || connection_status.can_write {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/src/api.rs
+++ b/src/api.rs
@@ -238,7 +238,7 @@ async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, A
             primary_available: false,
             replica_available: false,
         });
-    let redis_healthy = connection_status.can_read;
+    let redis_healthy = connection_status.can_write;
 
     let status = if connection_status.can_write {
         "healthy"
@@ -257,7 +257,7 @@ async fn health_check(State(db): State<AppState>) -> Result<impl IntoResponse, A
         timestamp: Utc::now().to_rfc3339(),
     };
 
-    let http_status = if connection_status.can_write || connection_status.can_read {
+    let http_status = if connection_status.can_write {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,10 @@ pub struct Config {
     pub redis_port: u16,
     pub redis_username: Option<String>,
     pub redis_password: Option<String>,
+    pub redis_replica_host: Option<String>,
+    pub redis_replica_port: Option<u16>,
+    pub redis_replica_username: Option<String>,
+    pub redis_replica_password: Option<String>,
     pub api_port: u16,
     pub ldap_port: u16,
     pub ldap_base_dn: String,
@@ -31,6 +35,12 @@ impl Config {
                 .unwrap_or(6379),
             redis_username: env::var("REDIS_USERNAME").ok(),
             redis_password: env::var("REDIS_PASSWORD").ok(),
+            redis_replica_host: env::var("REDIS_REPLICA_HOST").ok(),
+            redis_replica_port: env::var("REDIS_REPLICA_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+            redis_replica_username: env::var("REDIS_REPLICA_USERNAME").ok(),
+            redis_replica_password: env::var("REDIS_REPLICA_PASSWORD").ok(),
             api_port: env::var("API_PORT")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -57,18 +67,47 @@ impl Config {
     }
 
     pub fn redis_url(&self) -> String {
+        Self::build_redis_url(
+            &self.redis_host,
+            self.redis_port,
+            self.redis_username.as_deref(),
+            self.redis_password.as_deref(),
+        )
+    }
+
+    pub fn redis_replica_url(&self) -> Option<String> {
+        let host = self.redis_replica_host.as_deref()?;
+        let port = self.redis_replica_port.unwrap_or(self.redis_port);
+        let username = self
+            .redis_replica_username
+            .as_deref()
+            .or(self.redis_username.as_deref());
+        let password = self
+            .redis_replica_password
+            .as_deref()
+            .or(self.redis_password.as_deref());
+
+        Some(Self::build_redis_url(host, port, username, password))
+    }
+
+    fn build_redis_url(
+        host: &str,
+        port: u16,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> String {
         let mut url = "redis://".to_string();
 
-        if let (Some(username), Some(password)) = (&self.redis_username, &self.redis_password) {
+        if let (Some(username), Some(password)) = (username, password) {
             // ACL authentication with username and password
             let encoded_password = urlencoding::encode(password);
             url.push_str(&format!("{}:{}@", username, encoded_password));
-        } else if let Some(password) = &self.redis_password {
+        } else if let Some(password) = password {
             // Password-only authentication (default user)
             let encoded_password = urlencoding::encode(password);
             url.push_str(&format!(":{}@", encoded_password));
         }
-        url.push_str(&format!("{}:{}", self.redis_host, self.redis_port));
+        url.push_str(&format!("{}:{}", host, port));
         url
     }
 
@@ -77,6 +116,10 @@ impl Config {
         // Validate Redis port range
         if self.redis_port == 0 {
             anyhow::bail!("REDIS_PORT cannot be 0");
+        }
+
+        if self.redis_replica_host.is_some() && self.redis_replica_port == Some(0) {
+            anyhow::bail!("REDIS_REPLICA_PORT cannot be 0");
         }
 
         // Validate API port
@@ -118,5 +161,55 @@ impl Config {
             .map_err(|e| anyhow::anyhow!("Invalid LDAP_PORT {}: {}", self.ldap_port, e))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    fn base_config() -> Config {
+        Config {
+            redis_host: "primary.redis.local".to_string(),
+            redis_port: 6379,
+            redis_username: Some("primary-user".to_string()),
+            redis_password: Some("primary-pass".to_string()),
+            redis_replica_host: None,
+            redis_replica_port: None,
+            redis_replica_username: None,
+            redis_replica_password: None,
+            api_port: 8080,
+            ldap_port: 3389,
+            ldap_base_dn: "dc=example,dc=com".to_string(),
+            ldap_search_bind_org: None,
+            tls_cert_path: None,
+            tls_key_path: None,
+            enable_tls: false,
+        }
+    }
+
+    #[test]
+    fn test_replica_url_inherits_primary_auth() {
+        let mut config = base_config();
+        config.redis_replica_host = Some("replica.redis.local".to_string());
+
+        assert_eq!(
+            config.redis_replica_url().as_deref(),
+            Some("redis://primary-user:primary-pass@replica.redis.local:6379")
+        );
+    }
+
+    #[test]
+    fn test_replica_url_overrides_primary_auth() {
+        let mut config = base_config();
+        config.redis_replica_host = Some("replica.redis.local".to_string());
+        config.redis_replica_port = Some(6380);
+        config.redis_replica_username = Some("replica-user".to_string());
+        config.redis_replica_password = Some("replica-pass".to_string());
+
+        assert_eq!(
+            config.redis_replica_url().as_deref(),
+            Some("redis://replica-user:replica-pass@replica.redis.local:6380")
+        );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,6 +2,14 @@ use crate::error::Result;
 use crate::models::{Group, GroupCreate, GroupUpdate, User, UserCreate, UserUpdate};
 use async_trait::async_trait;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DbConnectionHealth {
+    pub can_read: bool,
+    pub can_write: bool,
+    pub primary_available: bool,
+    pub replica_available: bool,
+}
+
 /// Database service trait for abstracting storage operations
 /// This allows for easy testing and switching between different storage backends
 #[async_trait]
@@ -89,6 +97,17 @@ pub trait DbService: Send + Sync {
 
     /// Health check for the database connection
     async fn health_check(&self) -> Result<bool>;
+
+    /// Detailed health information for read/write availability.
+    async fn connection_status(&self) -> Result<DbConnectionHealth> {
+        let healthy = self.health_check().await?;
+        Ok(DbConnectionHealth {
+            can_read: healthy,
+            can_write: healthy,
+            primary_available: healthy,
+            replica_available: false,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,12 +66,22 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize database with retry logic
     let redis_url = config.redis_url();
+    let redis_replica_url = config.redis_replica_url();
     info!(
-        "Connecting to Redis at {}:{} (with retry logic)...",
+        "Connecting to Redis primary at {}:{} (with retry logic)...",
         config.redis_host, config.redis_port
     );
-    let db = Arc::new(RedisDbService::new(&redis_url, None).await?) as Arc<dyn db::DbService>;
-    info!("Successfully connected to Redis");
+    if let Some(replica_host) = &config.redis_replica_host {
+        info!(
+            "Configured Redis replica at {}:{} for read-only fallback",
+            replica_host,
+            config.redis_replica_port.unwrap_or(config.redis_port)
+        );
+    }
+    let db = Arc::new(
+        RedisDbService::new_with_replica(&redis_url, redis_replica_url.as_deref(), None).await?,
+    ) as Arc<dyn db::DbService>;
+    info!("Redis connectivity initialized");
 
     // Start API server with optional TLS
     let api_db = db.clone();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -86,17 +86,6 @@ pub mod custom {
         .expect("Failed to register user_operations counter")
     });
 
-    /// Legacy user operations counter (kept for backward compatibility)
-    #[allow(dead_code)]
-    pub static USER_OPERATIONS_LEGACY: Lazy<CounterVec> = Lazy::new(|| {
-        register_counter_vec!(
-            "user_operations_total",
-            "Total number of user operations",
-            &["organization", "operation", "result"]
-        )
-        .expect("Failed to register legacy user_operations counter")
-    });
-
     /// Group operations counter (create, update, delete, membership changes)
     #[allow(dead_code)]
     pub static GROUP_OPERATIONS: Lazy<CounterVec> = Lazy::new(|| {
@@ -106,17 +95,6 @@ pub mod custom {
             &["organization", "operation", "result"]
         )
         .expect("Failed to register group_operations counter")
-    });
-
-    /// Legacy group operations counter (kept for backward compatibility)
-    #[allow(dead_code)]
-    pub static GROUP_OPERATIONS_LEGACY: Lazy<CounterVec> = Lazy::new(|| {
-        register_counter_vec!(
-            "group_operations_total",
-            "Total number of group operations",
-            &["organization", "operation", "result"]
-        )
-        .expect("Failed to register legacy group_operations counter")
     });
 
     /// Total number of organizations tracked by the service
@@ -175,9 +153,6 @@ pub fn record_user_operation(org: &str, operation: &str, success: bool) {
     custom::USER_OPERATIONS
         .with_label_values(&[org, operation, result])
         .inc();
-    custom::USER_OPERATIONS_LEGACY
-        .with_label_values(&[org, operation, result])
-        .inc();
 }
 
 /// Helper function to record group operations
@@ -185,9 +160,6 @@ pub fn record_user_operation(org: &str, operation: &str, success: bool) {
 pub fn record_group_operation(org: &str, operation: &str, success: bool) {
     let result = if success { "success" } else { "failure" };
     custom::GROUP_OPERATIONS
-        .with_label_values(&[org, operation, result])
-        .inc();
-    custom::GROUP_OPERATIONS_LEGACY
         .with_label_values(&[org, operation, result])
         .inc();
 }

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -155,8 +155,8 @@ impl RedisDbService {
         let cfg = PoolConfig::from_url(redis_url);
         cfg.create_pool(Some(Runtime::Tokio1)).map_err(|err| {
             AppError::Database(format!(
-                "Failed to create Redis pool for {}: {}",
-                redis_url, err
+                "Failed to create Redis pool: {}",
+                err
             ))
         })
     }

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -23,6 +23,7 @@ pub struct RedisDbService {
 static RECONCILED_ORGS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 const METRICS_RECONCILE_INTERVAL_SECS: u64 = 60;
+const HEALTH_CHECK_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_millis(500);
 
 type RedisConnection = deadpool_redis::Connection;
 type RedisReadFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
@@ -173,6 +174,14 @@ impl RedisDbService {
             .map_err(|e| AppError::Database(format!("Failed to ping Redis: {}", e)))?;
 
         Ok(())
+    }
+
+    /// Test the Redis connection with a timeout to keep health checks responsive.
+    async fn test_connection_with_timeout(pool: &Pool, timeout: tokio::time::Duration) -> bool {
+        match tokio::time::timeout(timeout, Self::test_connection(pool)).await {
+            Ok(result) => result.is_ok(),
+            Err(_) => false,
+        }
     }
 
     async fn get_primary_conn(&self) -> Result<RedisConnection> {
@@ -1032,11 +1041,16 @@ impl DbService for RedisDbService {
     }
 
     async fn connection_status(&self) -> Result<DbConnectionHealth> {
-        let primary_available = Self::test_connection(&self.primary_pool).await.is_ok();
-        let replica_available = match self.replica_pool.as_ref() {
-            Some(pool) => Self::test_connection(pool).await.is_ok(),
-            None => false,
+        let primary_check =
+            Self::test_connection_with_timeout(&self.primary_pool, HEALTH_CHECK_TIMEOUT);
+        let replica_check = async {
+            match self.replica_pool.as_ref() {
+                Some(pool) => Self::test_connection_with_timeout(pool, HEALTH_CHECK_TIMEOUT).await,
+                None => false,
+            }
         };
+
+        let (primary_available, replica_available) = tokio::join!(primary_check, replica_check);
 
         Ok(DbConnectionHealth {
             can_read: primary_available || replica_available,

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -3,10 +3,12 @@ use chrono::Utc;
 use deadpool_redis::{Config as PoolConfig, Pool, Runtime, redis::AsyncCommands};
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use crate::db::DbService;
+use crate::db::{DbConnectionHealth, DbService};
 use crate::error::{AppError, Result};
 use crate::metrics;
 use crate::models::{Group, GroupCreate, GroupUpdate, User, UserCreate, UserUpdate};
@@ -14,78 +16,149 @@ use crate::password::{hash_password, verify_password};
 
 /// Redis-based implementation of the DbService trait
 pub struct RedisDbService {
-    pool: Pool,
+    primary_pool: Pool,
+    replica_pool: Option<Pool>,
 }
 
 static RECONCILED_ORGS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 const METRICS_RECONCILE_INTERVAL_SECS: u64 = 60;
 
+type RedisConnection = deadpool_redis::Connection;
+type RedisReadFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
 impl RedisDbService {
     /// Create a new RedisDbService from a Redis URL with retry logic
+    #[allow(dead_code)]
     pub async fn new(redis_url: &str, retry: Option<u32>) -> Result<Self> {
+        Self::new_with_replica(redis_url, None, retry).await
+    }
+
+    /// Create a new RedisDbService with an optional read-only replica URL.
+    pub async fn new_with_replica(
+        redis_url: &str,
+        replica_url: Option<&str>,
+        retry: Option<u32>,
+    ) -> Result<Self> {
         let retry = retry.unwrap_or(10);
-        Self::new_with_retry(redis_url, retry, tokio::time::Duration::from_secs(2)).await
+        Self::new_with_replica_and_retry(
+            redis_url,
+            replica_url,
+            retry,
+            tokio::time::Duration::from_secs(2),
+        )
+        .await
     }
 
     /// Create a new RedisDbService with configurable retry parameters
+    #[allow(dead_code)]
     pub async fn new_with_retry(
         redis_url: &str,
         max_retries: u32,
         initial_delay: tokio::time::Duration,
     ) -> Result<Self> {
+        Self::new_with_replica_and_retry(redis_url, None, max_retries, initial_delay).await
+    }
+
+    /// Create a new RedisDbService with replica-aware retry parameters.
+    pub async fn new_with_replica_and_retry(
+        redis_url: &str,
+        replica_url: Option<&str>,
+        max_retries: u32,
+        initial_delay: tokio::time::Duration,
+    ) -> Result<Self> {
+        let primary_pool = Self::create_pool(redis_url)?;
+        let replica_pool = match replica_url {
+            Some(url) => Some(Self::create_pool(url)?),
+            None => None,
+        };
+
         // Retry connection with exponential backoff
         let mut retries = 0;
         let mut delay = initial_delay;
 
         loop {
-            // Recreate the pool on each attempt to force DNS re-resolution
-            let cfg = PoolConfig::from_url(redis_url);
-            let pool = match cfg.create_pool(Some(Runtime::Tokio1)) {
-                Ok(pool) => pool,
-                Err(e) => {
-                    retries += 1;
-                    if retries >= max_retries {
-                        return Err(AppError::Database(format!(
-                            "Failed to create Redis pool after {} attempts: {}",
-                            max_retries, e
-                        )));
-                    }
-                    warn!(
-                        "Failed to create Redis pool (attempt {}/{}): {}. Retrying in {:?}...",
-                        retries, max_retries, e, delay
-                    );
-                    tokio::time::sleep(delay).await;
-                    delay = std::cmp::min(delay * 2, tokio::time::Duration::from_secs(30));
-                    continue;
-                }
+            let primary_result = Self::test_connection(&primary_pool).await;
+            let replica_result = match replica_pool.as_ref() {
+                Some(pool) => Some(Self::test_connection(pool).await),
+                None => None,
             };
 
-            match Self::test_connection(&pool).await {
-                Ok(_) => {
-                    info!("Successfully connected to Redis");
-                    let service = Self { pool: pool.clone() };
-                    service.start_metrics_reconciler();
-                    return Ok(service);
+            if primary_result.is_ok()
+                || replica_result.as_ref().is_some_and(|result| result.is_ok())
+            {
+                if primary_result.is_ok() {
+                    info!("Successfully connected to Redis primary");
                 }
-                Err(e) => {
-                    retries += 1;
-                    if retries >= max_retries {
-                        return Err(AppError::Database(format!(
-                            "Failed to connect to Redis after {} attempts: {}",
-                            max_retries, e
-                        )));
-                    }
-                    warn!(
-                        "Failed to connect to Redis (attempt {}/{}): {}. Retrying in {:?}...",
-                        retries, max_retries, e, delay
-                    );
-                    tokio::time::sleep(delay).await;
-                    // Exponential backoff with max 30 seconds
-                    delay = std::cmp::min(delay * 2, tokio::time::Duration::from_secs(30));
+
+                match replica_result.as_ref() {
+                    Some(Ok(_)) => info!("Successfully connected to Redis replica"),
+                    Some(Err(err)) => warn!(
+                        "Redis replica is configured but unavailable during startup: {}",
+                        err
+                    ),
+                    None => {}
                 }
+
+                if primary_result.is_err()
+                    && replica_result.as_ref().is_some_and(|result| result.is_ok())
+                {
+                    warn!("Starting in read-only degraded mode because Redis primary is offline");
+                }
+
+                let service = Self {
+                    primary_pool,
+                    replica_pool,
+                };
+                service.start_metrics_reconciler();
+                return Ok(service);
             }
+
+            retries += 1;
+            let primary_error = primary_result
+                .err()
+                .map(|err| err.to_string())
+                .unwrap_or_default();
+            let replica_error = replica_result
+                .and_then(|result| result.err())
+                .map(|err| err.to_string());
+
+            if retries >= max_retries {
+                let mut message = format!(
+                    "Failed to connect to Redis primary after {} attempts: {}",
+                    max_retries, primary_error
+                );
+                if let Some(replica_error) = replica_error {
+                    message.push_str(&format!("; replica also unavailable: {}", replica_error));
+                }
+                return Err(AppError::Database(message));
+            }
+
+            if let Some(replica_error) = replica_error {
+                warn!(
+                    "Redis primary and replica unavailable (attempt {}/{}): primary={}, replica={}. Retrying in {:?}...",
+                    retries, max_retries, primary_error, replica_error, delay
+                );
+            } else {
+                warn!(
+                    "Redis primary unavailable (attempt {}/{}): {}. Retrying in {:?}...",
+                    retries, max_retries, primary_error, delay
+                );
+            }
+
+            tokio::time::sleep(delay).await;
+            delay = std::cmp::min(delay * 2, tokio::time::Duration::from_secs(30));
         }
+    }
+
+    fn create_pool(redis_url: &str) -> Result<Pool> {
+        let cfg = PoolConfig::from_url(redis_url);
+        cfg.create_pool(Some(Runtime::Tokio1)).map_err(|err| {
+            AppError::Database(format!(
+                "Failed to create Redis pool for {}: {}",
+                redis_url, err
+            ))
+        })
     }
 
     /// Test the Redis connection
@@ -100,6 +173,97 @@ impl RedisDbService {
             .map_err(|e| AppError::Database(format!("Failed to ping Redis: {}", e)))?;
 
         Ok(())
+    }
+
+    async fn get_primary_conn(&self) -> Result<RedisConnection> {
+        self.primary_pool.get().await.map_err(AppError::from)
+    }
+
+    async fn get_replica_conn(&self) -> Result<RedisConnection> {
+        let replica_pool = self
+            .replica_pool
+            .as_ref()
+            .ok_or_else(|| AppError::Database("Redis replica is not configured".to_string()))?;
+
+        replica_pool.get().await.map_err(AppError::from)
+    }
+
+    async fn get_read_conn_from_pools(
+        primary_pool: &Pool,
+        replica_pool: Option<&Pool>,
+    ) -> Result<RedisConnection> {
+        match primary_pool.get().await {
+            Ok(conn) => Ok(conn),
+            Err(primary_err) => {
+                if let Some(replica_pool) = replica_pool {
+                    warn!(
+                        error = %primary_err,
+                        "Primary Redis unavailable while acquiring read connection, trying replica"
+                    );
+                    match replica_pool.get().await {
+                        Ok(conn) => Ok(conn),
+                        Err(replica_err) => Err(AppError::Database(format!(
+                            "Failed to get readable Redis connection; primary: {}, replica: {}",
+                            primary_err, replica_err
+                        ))),
+                    }
+                } else {
+                    Err(AppError::from(primary_err))
+                }
+            }
+        }
+    }
+
+    fn should_try_replica(error: &AppError) -> bool {
+        matches!(
+            error,
+            AppError::Database(_) | AppError::Redis(_) | AppError::Pool(_)
+        )
+    }
+
+    async fn with_read_fallback<T, F>(
+        &self,
+        operation_name: &'static str,
+        operation: F,
+    ) -> Result<T>
+    where
+        T: Send,
+        F: for<'a> Fn(&'a mut RedisConnection) -> RedisReadFuture<'a, T> + Send + Sync,
+    {
+        match self.primary_pool.get().await {
+            Ok(mut conn) => match operation(&mut conn).await {
+                Ok(result) => Ok(result),
+                Err(err) if self.replica_pool.is_some() && Self::should_try_replica(&err) => {
+                    warn!(
+                        operation = operation_name,
+                        error = %err,
+                        "Read against Redis primary failed, retrying against replica"
+                    );
+                    let mut replica_conn = self.get_replica_conn().await?;
+                    operation(&mut replica_conn).await
+                }
+                Err(err) => Err(err),
+            },
+            Err(primary_err) => {
+                if self.replica_pool.is_some() {
+                    warn!(
+                        operation = operation_name,
+                        error = %primary_err,
+                        "Primary Redis unavailable, using replica for read"
+                    );
+                    let mut replica_conn =
+                        self.get_replica_conn().await.map_err(|replica_err| {
+                            AppError::Database(format!(
+                                "Failed to get readable Redis connection; primary: {}, replica: {}",
+                                primary_err, replica_err
+                            ))
+                        })?;
+                    operation(&mut replica_conn).await
+                } else {
+                    Err(AppError::from(primary_err))
+                }
+            }
+        }
     }
 
     fn user_key(organization: &str, username: &str) -> String {
@@ -173,9 +337,10 @@ impl RedisDbService {
     }
 
     fn start_metrics_reconciler(&self) {
-        let pool = self.pool.clone();
+        let primary_pool = self.primary_pool.clone();
+        let replica_pool = self.replica_pool.clone();
         tokio::spawn(async move {
-            if let Err(e) = Self::reconcile_metrics(&pool).await {
+            if let Err(e) = Self::reconcile_metrics(&primary_pool, replica_pool.as_ref()).await {
                 warn!("Initial metrics reconciliation failed: {}", e);
             }
 
@@ -187,15 +352,16 @@ impl RedisDbService {
 
             loop {
                 interval.tick().await;
-                if let Err(e) = Self::reconcile_metrics(&pool).await {
+                if let Err(e) = Self::reconcile_metrics(&primary_pool, replica_pool.as_ref()).await
+                {
                     warn!("Periodic metrics reconciliation failed: {}", e);
                 }
             }
         });
     }
 
-    async fn reconcile_metrics(pool: &Pool) -> Result<()> {
-        let mut conn = pool.get().await?;
+    async fn reconcile_metrics(primary_pool: &Pool, replica_pool: Option<&Pool>) -> Result<()> {
+        let mut conn = Self::get_read_conn_from_pools(primary_pool, replica_pool).await?;
         let organizations: Vec<String> = conn.smembers(Self::organizations_key()).await?;
 
         for organization in &organizations {
@@ -214,6 +380,106 @@ impl RedisDbService {
 
         Ok(())
     }
+
+    async fn get_user_with_conn(
+        conn: &mut RedisConnection,
+        organization: &str,
+        username: &str,
+    ) -> Result<User> {
+        let key = Self::user_key(organization, username);
+        let user_json: Option<String> = conn.get(&key).await?;
+
+        match user_json {
+            Some(json) => Ok(serde_json::from_str(&json)?),
+            None => Err(AppError::NotFound(format!(
+                "User {}/{} not found",
+                organization, username
+            ))),
+        }
+    }
+
+    async fn list_users_with_conn(
+        conn: &mut RedisConnection,
+        organization: &str,
+    ) -> Result<Vec<User>> {
+        let usernames: Vec<String> = conn.smembers(Self::org_users_key(organization)).await?;
+
+        let mut users = Vec::new();
+        for username in usernames {
+            match Self::get_user_with_conn(conn, organization, &username).await {
+                Ok(user) => users.push(user),
+                Err(AppError::NotFound(_)) => warn!(
+                    "User {} listed in organization {} but not found in database",
+                    username, organization
+                ),
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(users)
+    }
+
+    async fn get_group_with_conn(
+        conn: &mut RedisConnection,
+        organization: &str,
+        name: &str,
+    ) -> Result<Group> {
+        let key = Self::group_key(organization, name);
+        let group_json: Option<String> = conn.get(&key).await?;
+
+        match group_json {
+            Some(json) => Ok(serde_json::from_str(&json)?),
+            None => Err(AppError::NotFound(format!(
+                "Group {}/{} not found",
+                organization, name
+            ))),
+        }
+    }
+
+    async fn list_groups_with_conn(
+        conn: &mut RedisConnection,
+        organization: &str,
+    ) -> Result<Vec<Group>> {
+        let group_names: Vec<String> = conn.smembers(Self::org_groups_key(organization)).await?;
+
+        let mut groups = Vec::new();
+        for name in group_names {
+            match Self::get_group_with_conn(conn, organization, &name).await {
+                Ok(group) => groups.push(group),
+                Err(AppError::NotFound(_)) => warn!(
+                    "Group {} listed in organization {} but not found in database",
+                    name, organization
+                ),
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(groups)
+    }
+
+    async fn get_user_groups_with_conn(
+        conn: &mut RedisConnection,
+        organization: &str,
+        username: &str,
+    ) -> Result<Vec<Group>> {
+        let group_names: Vec<String> = conn
+            .smembers(Self::user_groups_key(organization, username))
+            .await?;
+
+        let mut groups = Vec::new();
+        for name in group_names {
+            match Self::get_group_with_conn(conn, organization, &name).await {
+                Ok(group) => groups.push(group),
+                Err(AppError::NotFound(_)) => warn!(
+                    "Group {} listed for user {} in organization {} but not found in database",
+                    name, username, organization
+                ),
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(groups)
+    }
 }
 
 #[async_trait]
@@ -223,7 +489,7 @@ impl DbService for RedisDbService {
             "Creating user: organization={}, username={}",
             user.organization, user.username
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::user_key(&user.organization, &user.username);
 
         // Check if user already exists
@@ -273,20 +539,14 @@ impl DbService for RedisDbService {
             "Getting user: organization={}, username={}",
             organization, username
         );
-        let mut conn = self.pool.get().await?;
-        let key = Self::user_key(organization, username);
-
-        let user_json: Option<String> = conn.get(&key).await?;
-        match user_json {
-            Some(json) => {
-                let user: User = serde_json::from_str(&json)?;
-                Ok(user)
-            }
-            None => Err(AppError::NotFound(format!(
-                "User {}/{} not found",
-                organization, username
-            ))),
-        }
+        let organization_owned = organization.to_string();
+        let username_owned = username.to_string();
+        self.with_read_fallback("get_user", move |conn| {
+            let organization = organization_owned.clone();
+            let username = username_owned.clone();
+            Box::pin(async move { Self::get_user_with_conn(conn, &organization, &username).await })
+        })
+        .await
     }
 
     async fn update_user(
@@ -301,11 +561,11 @@ impl DbService for RedisDbService {
             username,
             update.password.is_some()
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::user_key(organization, username);
 
-        // Get existing user
-        let mut user = self.get_user(organization, username).await?;
+        // Get existing user from the primary for write consistency.
+        let mut user = Self::get_user_with_conn(&mut conn, organization, username).await?;
 
         // Update fields
         if let Some(password) = update.password {
@@ -337,7 +597,7 @@ impl DbService for RedisDbService {
             "Deleting user: organization={}, username={}",
             organization, username
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::user_key(organization, username);
 
         // Check if user exists
@@ -418,22 +678,13 @@ impl DbService for RedisDbService {
 
     async fn list_users(&self, organization: &str) -> Result<Vec<User>> {
         info!("Listing users: organization={}", organization);
-        let mut conn = self.pool.get().await?;
-        let org_users_key = Self::org_users_key(organization);
-
-        let usernames: Vec<String> = conn.smembers(&org_users_key).await?;
-
-        let mut users = Vec::new();
-        for username in usernames {
-            if let Ok(user) = self.get_user(organization, &username).await {
-                users.push(user);
-            } else {
-                warn!(
-                    "User {} listed in organization {} but not found in database",
-                    username, organization
-                );
-            }
-        }
+        let organization_owned = organization.to_string();
+        let users = self
+            .with_read_fallback("list_users", move |conn| {
+                let organization = organization_owned.clone();
+                Box::pin(async move { Self::list_users_with_conn(conn, &organization).await })
+            })
+            .await?;
 
         info!(
             "Successfully listed {} users: organization={}",
@@ -453,7 +704,17 @@ impl DbService for RedisDbService {
             "Verifying user password: organization={}, username={}",
             organization, username
         );
-        let user = self.get_user(organization, username).await?;
+        let organization_owned = organization.to_string();
+        let username_owned = username.to_string();
+        let user = self
+            .with_read_fallback("verify_user_password", move |conn| {
+                let organization = organization_owned.clone();
+                let username = username_owned.clone();
+                Box::pin(
+                    async move { Self::get_user_with_conn(conn, &organization, &username).await },
+                )
+            })
+            .await?;
         let result = verify_password(password, &user.password_hash)?;
         Ok(result)
     }
@@ -463,7 +724,7 @@ impl DbService for RedisDbService {
             "Creating group: organization={}, name={}, description={:?}",
             group.organization, group.name, group.description
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::group_key(&group.organization, &group.name);
 
         // Check if group already exists
@@ -504,20 +765,14 @@ impl DbService for RedisDbService {
             "Getting group: organization={}, name={}",
             organization, name
         );
-        let mut conn = self.pool.get().await?;
-        let key = Self::group_key(organization, name);
-
-        let group_json: Option<String> = conn.get(&key).await?;
-        match group_json {
-            Some(json) => {
-                let group: Group = serde_json::from_str(&json)?;
-                Ok(group)
-            }
-            None => Err(AppError::NotFound(format!(
-                "Group {}/{} not found",
-                organization, name
-            ))),
-        }
+        let organization_owned = organization.to_string();
+        let name_owned = name.to_string();
+        self.with_read_fallback("get_group", move |conn| {
+            let organization = organization_owned.clone();
+            let name = name_owned.clone();
+            Box::pin(async move { Self::get_group_with_conn(conn, &organization, &name).await })
+        })
+        .await
     }
 
     async fn update_group(
@@ -530,11 +785,11 @@ impl DbService for RedisDbService {
             "Updating group: organization={}, name={}, description={:?}",
             organization, name, update.description
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::group_key(organization, name);
 
-        // Get existing group
-        let mut group = self.get_group(organization, name).await?;
+        // Get existing group from the primary for write consistency.
+        let mut group = Self::get_group_with_conn(&mut conn, organization, name).await?;
 
         // Update fields
         if let Some(description) = update.description {
@@ -558,11 +813,11 @@ impl DbService for RedisDbService {
             "Deleting group: organization={}, name={}",
             organization, name
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
         let key = Self::group_key(organization, name);
 
         // Check if group exists
-        let group = self.get_group(organization, name).await?;
+        let group = Self::get_group_with_conn(&mut conn, organization, name).await?;
 
         // Remove group from all users' group sets
         for username in &group.members {
@@ -592,19 +847,12 @@ impl DbService for RedisDbService {
 
     async fn list_groups(&self, organization: &str) -> Result<Vec<Group>> {
         info!("Listing groups: organization={}", organization);
-        let mut conn = self.pool.get().await?;
-        let org_groups_key = Self::org_groups_key(organization);
-
-        let group_names: Vec<String> = conn.smembers(&org_groups_key).await?;
-
-        let mut groups = Vec::new();
-        for name in group_names {
-            if let Ok(group) = self.get_group(organization, &name).await {
-                groups.push(group);
-            }
-        }
-
-        Ok(groups)
+        let organization_owned = organization.to_string();
+        self.with_read_fallback("list_groups", move |conn| {
+            let organization = organization_owned.clone();
+            Box::pin(async move { Self::list_groups_with_conn(conn, &organization).await })
+        })
+        .await
     }
 
     async fn add_user_to_group(
@@ -617,13 +865,13 @@ impl DbService for RedisDbService {
             "Adding user to group: organization={}, group={}, username={}",
             organization, group_name, username
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
 
         // Verify user exists
-        self.get_user(organization, username).await?;
+        Self::get_user_with_conn(&mut conn, organization, username).await?;
 
         // Get group
-        let mut group = self.get_group(organization, group_name).await?;
+        let mut group = Self::get_group_with_conn(&mut conn, organization, group_name).await?;
 
         // Add user to group
         if !group.add_member(username.to_string()) {
@@ -659,10 +907,10 @@ impl DbService for RedisDbService {
             "Removing user from group: organization={}, group={}, username={}",
             organization, group_name, username
         );
-        let mut conn = self.pool.get().await?;
+        let mut conn = self.get_primary_conn().await?;
 
         // Get group
-        let mut group = self.get_group(organization, group_name).await?;
+        let mut group = Self::get_group_with_conn(&mut conn, organization, group_name).await?;
 
         // Remove user from group
         if !group.remove_member(username) {
@@ -693,17 +941,17 @@ impl DbService for RedisDbService {
             "Getting user groups: organization={}, username={}",
             organization, username
         );
-        let mut conn = self.pool.get().await?;
-        let user_groups_key = Self::user_groups_key(organization, username);
-
-        let group_names: Vec<String> = conn.smembers(&user_groups_key).await?;
-
-        let mut groups = Vec::new();
-        for name in group_names {
-            if let Ok(group) = self.get_group(organization, &name).await {
-                groups.push(group);
-            }
-        }
+        let organization_owned = organization.to_string();
+        let username_owned = username.to_string();
+        let groups = self
+            .with_read_fallback("get_user_groups", move |conn| {
+                let organization = organization_owned.clone();
+                let username = username_owned.clone();
+                Box::pin(async move {
+                    Self::get_user_groups_with_conn(conn, &organization, &username).await
+                })
+            })
+            .await?;
 
         info!(
             "Successfully retrieved {} groups for user: organization={}, username={}",
@@ -719,8 +967,13 @@ impl DbService for RedisDbService {
             "Searching users: organization={}, filter={}",
             organization, filter
         );
-        // Simple implementation: list all users and filter by username or email
-        let users = self.list_users(organization).await?;
+        let organization_owned = organization.to_string();
+        let users = self
+            .with_read_fallback("search_users", move |conn| {
+                let organization = organization_owned.clone();
+                Box::pin(async move { Self::list_users_with_conn(conn, &organization).await })
+            })
+            .await?;
 
         let filtered: Vec<User> = users
             .into_iter()
@@ -745,8 +998,13 @@ impl DbService for RedisDbService {
             "Searching groups: organization={}, filter={}",
             organization, filter
         );
-        // Simple implementation: list all groups and filter by name or description
-        let groups = self.list_groups(organization).await?;
+        let organization_owned = organization.to_string();
+        let groups = self
+            .with_read_fallback("search_groups", move |conn| {
+                let organization = organization_owned.clone();
+                Box::pin(async move { Self::list_groups_with_conn(conn, &organization).await })
+            })
+            .await?;
 
         let filtered: Vec<Group> = groups
             .into_iter()
@@ -767,13 +1025,25 @@ impl DbService for RedisDbService {
 
     async fn health_check(&self) -> Result<bool> {
         info!("Performing database health check");
-        let mut conn = self.pool.get().await?;
-        let result: deadpool_redis::redis::RedisResult<String> = deadpool_redis::redis::cmd("PING")
-            .query_async(&mut conn)
-            .await;
-        let is_healthy = result.is_ok();
+        let status = self.connection_status().await?;
+        let is_healthy = status.can_read;
         info!("Database health check result: {}", is_healthy);
         Ok(is_healthy)
+    }
+
+    async fn connection_status(&self) -> Result<DbConnectionHealth> {
+        let primary_available = Self::test_connection(&self.primary_pool).await.is_ok();
+        let replica_available = match self.replica_pool.as_ref() {
+            Some(pool) => Self::test_connection(pool).await.is_ok(),
+            None => false,
+        };
+
+        Ok(DbConnectionHealth {
+            can_read: primary_available || replica_available,
+            can_write: primary_available,
+            primary_available,
+            replica_available,
+        })
     }
 }
 

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -79,9 +79,12 @@ impl RedisDbService {
         let mut delay = initial_delay;
 
         loop {
-            let primary_result = Self::test_connection(&primary_pool).await;
+            let primary_result =
+                Self::test_connection_with_timeout(&primary_pool, HEALTH_CHECK_TIMEOUT).await;
             let replica_result = match replica_pool.as_ref() {
-                Some(pool) => Some(Self::test_connection(pool).await),
+                Some(pool) => {
+                    Some(Self::test_connection_with_timeout(pool, HEALTH_CHECK_TIMEOUT).await)
+                }
                 None => None,
             };
 
@@ -172,11 +175,17 @@ impl RedisDbService {
         Ok(())
     }
 
-    /// Test the Redis connection with a timeout to keep health checks responsive.
-    async fn test_connection_with_timeout(pool: &Pool, timeout: tokio::time::Duration) -> bool {
+    /// Test the Redis connection with a timeout to keep probes bounded.
+    async fn test_connection_with_timeout(
+        pool: &Pool,
+        timeout: tokio::time::Duration,
+    ) -> Result<()> {
         match tokio::time::timeout(timeout, Self::test_connection(pool)).await {
-            Ok(result) => result.is_ok(),
-            Err(_) => false,
+            Ok(result) => result,
+            Err(_) => Err(AppError::Database(format!(
+                "Redis probe timed out after {:?}",
+                timeout
+            ))),
         }
     }
 
@@ -1041,13 +1050,17 @@ impl DbService for RedisDbService {
         // dead primary cannot starve the replica check on a shared Tokio worker.
         let primary_pool = self.primary_pool.clone();
         let primary_task = tokio::spawn(async move {
-            Self::test_connection_with_timeout(&primary_pool, HEALTH_CHECK_TIMEOUT).await
+            Self::test_connection_with_timeout(&primary_pool, HEALTH_CHECK_TIMEOUT)
+                .await
+                .is_ok()
         });
 
         let replica_pool = self.replica_pool.clone();
         let replica_task = tokio::spawn(async move {
             match replica_pool.as_ref() {
-                Some(pool) => Self::test_connection_with_timeout(pool, HEALTH_CHECK_TIMEOUT).await,
+                Some(pool) => Self::test_connection_with_timeout(pool, HEALTH_CHECK_TIMEOUT)
+                    .await
+                    .is_ok(),
                 None => false,
             }
         });

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -154,12 +154,8 @@ impl RedisDbService {
 
     fn create_pool(redis_url: &str) -> Result<Pool> {
         let cfg = PoolConfig::from_url(redis_url);
-        cfg.create_pool(Some(Runtime::Tokio1)).map_err(|err| {
-            AppError::Database(format!(
-                "Failed to create Redis pool: {}",
-                err
-            ))
-        })
+        cfg.create_pool(Some(Runtime::Tokio1))
+            .map_err(|err| AppError::Database(format!("Failed to create Redis pool: {}", err)))
     }
 
     /// Test the Redis connection

--- a/src/redis_db.rs
+++ b/src/redis_db.rs
@@ -23,7 +23,7 @@ pub struct RedisDbService {
 static RECONCILED_ORGS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 const METRICS_RECONCILE_INTERVAL_SECS: u64 = 60;
-const HEALTH_CHECK_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_millis(500);
+const HEALTH_CHECK_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_millis(1500);
 
 type RedisConnection = deadpool_redis::Connection;
 type RedisReadFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
@@ -1037,16 +1037,24 @@ impl DbService for RedisDbService {
     }
 
     async fn connection_status(&self) -> Result<DbConnectionHealth> {
-        let primary_check =
-            Self::test_connection_with_timeout(&self.primary_pool, HEALTH_CHECK_TIMEOUT);
-        let replica_check = async {
-            match self.replica_pool.as_ref() {
+        // Spawn each check in its own task so a blocking pool.get() against the
+        // dead primary cannot starve the replica check on a shared Tokio worker.
+        let primary_pool = self.primary_pool.clone();
+        let primary_task = tokio::spawn(async move {
+            Self::test_connection_with_timeout(&primary_pool, HEALTH_CHECK_TIMEOUT).await
+        });
+
+        let replica_pool = self.replica_pool.clone();
+        let replica_task = tokio::spawn(async move {
+            match replica_pool.as_ref() {
                 Some(pool) => Self::test_connection_with_timeout(pool, HEALTH_CHECK_TIMEOUT).await,
                 None => false,
             }
-        };
+        });
 
-        let (primary_available, replica_available) = tokio::join!(primary_check, replica_check);
+        let (primary_result, replica_result) = tokio::join!(primary_task, replica_task);
+        let primary_available = primary_result.unwrap_or(false);
+        let replica_available = replica_result.unwrap_or(false);
 
         Ok(DbConnectionHealth {
             can_read: primary_available || replica_available,

--- a/tests/ldap_integration_test.rs
+++ b/tests/ldap_integration_test.rs
@@ -1,10 +1,16 @@
 use ldap_auth_rs::{
     db::DbService, ldap::LdapServer, models::UserCreate, redis_db::RedisDbService, tls,
 };
+use redis::AsyncCommands;
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pki_types::ServerName;
 use std::io::BufReader;
 use std::sync::Arc;
+use testcontainers::{
+    GenericImage,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::{Duration, sleep};
@@ -19,6 +25,25 @@ async fn setup_test_db() -> Arc<dyn DbService> {
             .await
             .expect("Failed to connect to Redis"),
     )
+}
+
+async fn flush_redis_db(redis_url: &str) {
+    let client = redis::Client::open(redis_url).expect("Failed to create Redis client");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("Failed to connect to Redis");
+    conn.flushdb::<()>()
+        .await
+        .expect("Failed to flush Redis DB");
+}
+
+async fn setup_replica_only_test_db(primary_url: &str, replica_url: &str) -> Arc<dyn DbService> {
+    Arc::new(
+        RedisDbService::new_with_replica(primary_url, Some(replica_url), Some(1))
+            .await
+            .expect("Failed to connect to replica-backed Redis service"),
+    ) as Arc<dyn DbService>
 }
 
 async fn start_ldap_server(db: Arc<dyn DbService>, port: u16) {
@@ -220,6 +245,71 @@ fn parse_bind_response(data: &[u8]) -> Result<u8, String> {
     }
 
     Err("Result code not found".to_string())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_ldap_bind_uses_replica_when_primary_is_offline() {
+    let replica_container = GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379.tcp())
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await
+        .expect("Failed to start Redis replica container");
+    let replica_port = replica_container
+        .get_host_port_ipv4(6379.tcp())
+        .await
+        .expect("Failed to resolve Redis replica port");
+    let primary_url = "redis://127.0.0.1:1/0";
+    let replica_url = format!("redis://127.0.0.1:{}/0", replica_port);
+    let seeding_db = RedisDbService::new(&replica_url, Some(1))
+        .await
+        .expect("Failed to connect to replica Redis for seeding");
+    let port = 13410;
+
+    flush_redis_db(&replica_url).await;
+
+    let user_create = UserCreate {
+        organization: "replicaorg".to_string(),
+        username: "replicauser".to_string(),
+        password: "replicapass123".to_string(),
+        email: Some("replica@example.com".to_string()),
+        full_name: None,
+    };
+    seeding_db
+        .create_user(user_create)
+        .await
+        .expect("Failed to create replica-backed user");
+
+    let db = setup_replica_only_test_db(primary_url, &replica_url).await;
+    start_ldap_server(db, port).await;
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+        .await
+        .expect("Failed to connect");
+
+    let dn = "cn=replicauser,ou=replicaorg,dc=example,dc=com";
+    let bind_request = create_bind_request(1, dn, "replicapass123");
+
+    stream
+        .write_all(&bind_request)
+        .await
+        .expect("Failed to send bind");
+
+    let mut response = vec![0u8; 1024];
+    let n = stream
+        .read(&mut response)
+        .await
+        .expect("Failed to read response");
+    let response = &response[..n];
+
+    let result_code = parse_bind_response(response).expect("Failed to parse response");
+    assert_eq!(
+        result_code, 0,
+        "Bind should succeed via replica when the primary is offline"
+    );
+
+    flush_redis_db(&replica_url).await;
 }
 
 #[tokio::test]

--- a/tests/ldap_integration_test.rs
+++ b/tests/ldap_integration_test.rs
@@ -267,12 +267,14 @@ async fn test_ldap_bind_uses_replica_when_primary_is_offline() {
         .expect("Failed to connect to replica Redis for seeding");
     let port = 13410;
 
+    const REPLICA_TEST_PASSWORD: &str = "replicapass123";
+
     flush_redis_db(&replica_url).await;
 
     let user_create = UserCreate {
         organization: "replicaorg".to_string(),
         username: "replicauser".to_string(),
-        password: "replicapass123".to_string(),
+        password: REPLICA_TEST_PASSWORD.to_string(),
         email: Some("replica@example.com".to_string()),
         full_name: None,
     };
@@ -289,7 +291,7 @@ async fn test_ldap_bind_uses_replica_when_primary_is_offline() {
         .expect("Failed to connect");
 
     let dn = "cn=replicauser,ou=replicaorg,dc=example,dc=com";
-    let bind_request = create_bind_request(1, dn, "replicapass123");
+    let bind_request = create_bind_request(1, dn, REPLICA_TEST_PASSWORD);
 
     stream
         .write_all(&bind_request)

--- a/tests/ldap_replica_failover_test.sh
+++ b/tests/ldap_replica_failover_test.sh
@@ -2,20 +2,65 @@
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
-API_URL="${API_URL:-http://127.0.0.1:8080}"
-LDAP_URL="${LDAP_URL:-ldap://127.0.0.1:3389}"
 API_TOKEN="${API_TOKEN:-asdf}"
 TEST_ORG="${TEST_ORG:-replicaorg}"
 TEST_USER="${TEST_USER:-replicauser}"
 TEST_PASSWORD="${TEST_PASSWORD:-replicapass123}"
 BASE_DN="${BASE_DN:-dc=example,dc=com}"
 
+# Resolve compose file to absolute path before we cd elsewhere
+COMPOSE_FILE="$(cd "$(dirname "$0")/.." && pwd)/${COMPOSE_FILE##*/}"
+
+# Choose LDAP host port: use 3389 if free, otherwise pick an ephemeral port.
+# All API calls run inside the container via docker exec, so port 8080 never
+# needs to be bound on the host. We generate a temp compose file that removes
+# port 8080 from the ldap-auth service binding entirely.
+if lsof -i tcp:3389 -sTCP:LISTEN >/dev/null 2>&1; then
+  LDAP_HOST_PORT=13389
+else
+  LDAP_HOST_PORT=3389
+fi
+LDAP_URL="${LDAP_URL:-ldap://127.0.0.1:${LDAP_HOST_PORT}}"
+
+# Build a temp compose file that binds only the LDAP port (no API port needed
+# from host since all API probes go through docker exec).
+_TMPDIR=$(mktemp -d)
+_TEST_COMPOSE="${_TMPDIR}/docker-compose.failover.yml"
+_REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 - <<PYEOF
+import yaml, os
+
+with open("${COMPOSE_FILE}") as f:
+    cfg = yaml.safe_load(f)
+
+svc = cfg["services"]["ldap-auth"]
+
+# Make build context absolute so the generated file works from any cwd
+build = svc.get("build", {})
+if isinstance(build, dict):
+    ctx = build.get("context", ".")
+    if not os.path.isabs(ctx):
+        build["context"] = os.path.normpath(os.path.join("${_REPO_ROOT}", ctx))
+    svc["build"] = build
+elif isinstance(build, str):
+    if not os.path.isabs(build):
+        svc["build"] = os.path.normpath(os.path.join("${_REPO_ROOT}", build))
+
+# Replace ports: only expose LDAP port on the chosen host port
+svc["ports"] = ["${LDAP_HOST_PORT}:3389"]
+
+with open("${_TEST_COMPOSE}", "w") as f:
+    yaml.dump(cfg, f, default_flow_style=False)
+PYEOF
+
 cleanup() {
-  docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+  docker compose -f "$_TEST_COMPOSE" down -v >/dev/null 2>&1 || true
+  rm -rf "$_TMPDIR"
 }
 
 container_api() {
-  docker compose -f "$COMPOSE_FILE" exec -T ldap-auth curl -fsS "$@"
+  docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth curl -fsS "$@"
 }
 
 wait_for_api() {
@@ -32,7 +77,7 @@ wait_for_api() {
 
 wait_for_replication() {
   for _ in $(seq 1 30); do
-    if docker compose -f "$COMPOSE_FILE" exec -T redis-replica redis-cli -p 6391 GET "user:${TEST_ORG}:${TEST_USER}" | grep -q 'organization'; then
+    if docker compose -f "$_TEST_COMPOSE" exec -T redis-replica redis-cli -p 6391 GET "user:${TEST_ORG}:${TEST_USER}" | grep -q 'organization'; then
       return 0
     fi
     sleep 1
@@ -50,23 +95,31 @@ JSON
 )
 
   local response
-  response=$(docker compose -f "$COMPOSE_FILE" exec -T ldap-auth curl -sS -o /tmp/ldap-replica-create-user.out -w "%{http_code}" \
+  response=$(docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth curl -sS -o /tmp/ldap-replica-create-user.out -w "%{http_code}" \
     -X POST "http://127.0.0.1:8080/api/users" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $API_TOKEN" \
     -d "$payload")
 
   if [[ "$response" != "201" && "$response" != "409" ]]; then
-    docker compose -f "$COMPOSE_FILE" exec -T ldap-auth cat /tmp/ldap-replica-create-user.out >&2 || true
+    docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth cat /tmp/ldap-replica-create-user.out >&2 || true
     echo "Failed to create test user, HTTP $response" >&2
     return 1
   fi
 }
 
 assert_health_degraded() {
-  local body
-  body=$(container_api "http://127.0.0.1:8080/health")
-  echo "$body" | grep -q '"status":"degraded"'
+  for _ in $(seq 1 20); do
+    local body
+    if body=$(container_api "http://127.0.0.1:8080/health" 2>/dev/null); then
+      if echo "$body" | grep -q '"status":"degraded"'; then
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "Health status did not transition to degraded within 20 seconds" >&2
+  return 1
 }
 
 assert_ldap_bind_works() {
@@ -92,7 +145,7 @@ if ! command -v ldapsearch >/dev/null 2>&1; then
 fi
 
 echo "Starting compose stack with Redis primary and replica..."
-docker compose -f "$COMPOSE_FILE" up -d --build redis redis-replica ldap-auth
+docker compose -f "$_TEST_COMPOSE" up -d --build redis redis-replica ldap-auth
 
 echo "Waiting for API..."
 wait_for_api
@@ -104,7 +157,7 @@ echo "Waiting for data to reach replica..."
 wait_for_replication
 
 echo "Stopping Redis primary to simulate failure..."
-docker compose -f "$COMPOSE_FILE" stop redis >/dev/null
+docker compose -f "$_TEST_COMPOSE" stop redis >/dev/null
 sleep 2
 
 echo "Checking health degraded mode..."

--- a/tests/ldap_replica_failover_test.sh
+++ b/tests/ldap_replica_failover_test.sh
@@ -116,7 +116,7 @@ assert_health_degraded() {
   for _ in $(seq 1 20); do
     local status_code
     status_code=$(container_api_with_status "http://127.0.0.1:8080/health" 2>/dev/null || true)
-    if [[ "$status_code" == "503" ]]; then
+    if [[ "$status_code" == "200" ]]; then
       local body
       body=$(docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth cat /tmp/ldap-replica-health.out 2>/dev/null || true)
       if echo "$body" | grep -q '"status":"degraded"'; then

--- a/tests/ldap_replica_failover_test.sh
+++ b/tests/ldap_replica_failover_test.sh
@@ -63,6 +63,10 @@ container_api() {
   docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth curl -fsS "$@"
 }
 
+container_api_with_status() {
+  docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth curl -sS -o /tmp/ldap-replica-health.out -w "%{http_code}" "$@"
+}
+
 wait_for_api() {
   for _ in $(seq 1 60); do
     if container_api "http://127.0.0.1:8080/health" >/dev/null; then
@@ -110,8 +114,11 @@ JSON
 
 assert_health_degraded() {
   for _ in $(seq 1 20); do
-    local body
-    if body=$(container_api "http://127.0.0.1:8080/health" 2>/dev/null); then
+    local status_code
+    status_code=$(container_api_with_status "http://127.0.0.1:8080/health" 2>/dev/null || true)
+    if [[ "$status_code" == "503" ]]; then
+      local body
+      body=$(docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth cat /tmp/ldap-replica-health.out 2>/dev/null || true)
       if echo "$body" | grep -q '"status":"degraded"'; then
         return 0
       fi
@@ -119,6 +126,7 @@ assert_health_degraded() {
     sleep 1
   done
   echo "Health status did not transition to degraded within 20 seconds" >&2
+  docker compose -f "$_TEST_COMPOSE" exec -T ldap-auth cat /tmp/ldap-replica-health.out >&2 2>/dev/null || true
   return 1
 }
 

--- a/tests/ldap_replica_failover_test.sh
+++ b/tests/ldap_replica_failover_test.sh
@@ -125,11 +125,20 @@ assert_health_degraded() {
 assert_ldap_bind_works() {
   local bind_dn="cn=${TEST_USER},ou=${TEST_ORG},${BASE_DN}"
 
-  ldapsearch -x -H "$LDAP_URL" \
-    -D "$bind_dn" \
-    -w "$TEST_PASSWORD" \
-    -b "$BASE_DN" \
-    -s base '(objectclass=*)' >/tmp/ldap-replica-bind.out 2>&1
+  for _ in $(seq 1 20); do
+    if ldapsearch -x -H "$LDAP_URL" \
+      -D "$bind_dn" \
+      -w "$TEST_PASSWORD" \
+      -b "$BASE_DN" \
+      -s base '(objectclass=*)' >/tmp/ldap-replica-bind.out 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "LDAP bind did not succeed within 20 seconds after primary shutdown" >&2
+  cat /tmp/ldap-replica-bind.out >&2 || true
+  return 1
 }
 
 trap cleanup EXIT

--- a/tests/ldap_replica_failover_test.sh
+++ b/tests/ldap_replica_failover_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
+API_URL="${API_URL:-http://127.0.0.1:8080}"
+LDAP_URL="${LDAP_URL:-ldap://127.0.0.1:3389}"
+API_TOKEN="${API_TOKEN:-asdf}"
+TEST_ORG="${TEST_ORG:-replicaorg}"
+TEST_USER="${TEST_USER:-replicauser}"
+TEST_PASSWORD="${TEST_PASSWORD:-replicapass123}"
+BASE_DN="${BASE_DN:-dc=example,dc=com}"
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+
+container_api() {
+  docker compose -f "$COMPOSE_FILE" exec -T ldap-auth curl -fsS "$@"
+}
+
+wait_for_api() {
+  for _ in $(seq 1 60); do
+    if container_api "http://127.0.0.1:8080/health" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "API did not become ready in time" >&2
+  return 1
+}
+
+wait_for_replication() {
+  for _ in $(seq 1 30); do
+    if docker compose -f "$COMPOSE_FILE" exec -T redis-replica redis-cli -p 6391 GET "user:${TEST_ORG}:${TEST_USER}" | grep -q 'organization'; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Replica did not receive test user in time" >&2
+  return 1
+}
+
+create_test_user() {
+  local payload
+  payload=$(cat <<JSON
+{"organization":"${TEST_ORG}","username":"${TEST_USER}","password":"${TEST_PASSWORD}","email":"${TEST_USER}@${TEST_ORG}.com"}
+JSON
+)
+
+  local response
+  response=$(docker compose -f "$COMPOSE_FILE" exec -T ldap-auth curl -sS -o /tmp/ldap-replica-create-user.out -w "%{http_code}" \
+    -X POST "http://127.0.0.1:8080/api/users" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $API_TOKEN" \
+    -d "$payload")
+
+  if [[ "$response" != "201" && "$response" != "409" ]]; then
+    docker compose -f "$COMPOSE_FILE" exec -T ldap-auth cat /tmp/ldap-replica-create-user.out >&2 || true
+    echo "Failed to create test user, HTTP $response" >&2
+    return 1
+  fi
+}
+
+assert_health_degraded() {
+  local body
+  body=$(container_api "http://127.0.0.1:8080/health")
+  echo "$body" | grep -q '"status":"degraded"'
+}
+
+assert_ldap_bind_works() {
+  local bind_dn="cn=${TEST_USER},ou=${TEST_ORG},${BASE_DN}"
+
+  ldapsearch -x -H "$LDAP_URL" \
+    -D "$bind_dn" \
+    -w "$TEST_PASSWORD" \
+    -b "$BASE_DN" \
+    -s base '(objectclass=*)' >/tmp/ldap-replica-bind.out 2>&1
+}
+
+trap cleanup EXIT
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+if ! command -v ldapsearch >/dev/null 2>&1; then
+  echo "ldapsearch is required" >&2
+  exit 1
+fi
+
+echo "Starting compose stack with Redis primary and replica..."
+docker compose -f "$COMPOSE_FILE" up -d --build redis redis-replica ldap-auth
+
+echo "Waiting for API..."
+wait_for_api
+
+echo "Creating LDAP test user through the primary..."
+create_test_user
+
+echo "Waiting for data to reach replica..."
+wait_for_replication
+
+echo "Stopping Redis primary to simulate failure..."
+docker compose -f "$COMPOSE_FILE" stop redis >/dev/null
+sleep 2
+
+echo "Checking health degraded mode..."
+assert_health_degraded
+
+echo "Checking LDAP bind through replica fallback..."
+assert_ldap_bind_works
+
+echo "Replica failover LDAP bind test passed"


### PR DESCRIPTION
- Refactor test script to use Docker Compose for Redis primary/replica setup.
- Enhance health check API to report Redis primary and replica status.
- Update configuration to include replica Redis settings.
- Modify Redis database service to handle connections to both primary and replica.
- Implement read fallback logic to use replica when primary is unavailable.
- Add integration tests for LDAP bind functionality using replica during primary failure.
- Create a new shell script for testing LDAP replica failover scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis read-replica support with automatic read fallback and degraded read-only mode
  * Health endpoint now reports granular status (healthy/degraded/unhealthy) and shows primary/replica/read-only state

* **Documentation**
  * Configuration docs updated with replica env vars, examples, and revised health semantics
  * Added deployment manifests for a Redis replica

* **Tests**
  * New integration and end-to-end failover tests (compose-based and CI-run)

* **Chores**
  * CI workflow added failover test gating and action pins refreshed
  * Removed legacy metrics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->